### PR TITLE
Susburrows/qflx lhflx conversions

### DIFF
--- a/src/python/computation/reductions.py
+++ b/src/python/computation/reductions.py
@@ -1593,7 +1593,7 @@ def convert_qflx_to_Wms(qflx):
 #                                  preferred_units='W/m^2')
     # 1 W = 86.4 kJ / day
         lhflx = qflxtmp * 86.4
-        lhflx.units = 'W/m^s'
+        lhflx.units = 'W/m^2'
     else:
         print "ERROR: In function convert_qflx_to_Wms, input variable qflx must have units of mm/day."
         exit

--- a/src/python/computation/reductions.py
+++ b/src/python/computation/reductions.py
@@ -1590,9 +1590,12 @@ def convert_qflx_to_Wms(qflx):
         qflx.units='kg/m2/day'
         qflxtmp = lhvap*qflx
         qflxtmp.units = 'kJ/m2/day'
-        qflxWms = reconcile_units(qflxtmp, udunits(1,'W/m2'),
+        lhflx = reconcile_units(qflxtmp, udunits(1,'W/m2'),
                                   preferred_units='W/m2')
-    return qflxWms
+    else:
+        print "ERROR: In function convert_qflx_to_Wms, input variable qflx must have units of mm/day."
+        exit
+    return lhflx
 
 def reconcile_units( mv1, mv2, preferred_units=None ):
     """Changes the units of variables (instances of TransientVariable) mv1,mv2 to be the same,

--- a/src/python/computation/reductions.py
+++ b/src/python/computation/reductions.py
@@ -1586,11 +1586,14 @@ def convert_qflx_to_Wms(qflx):
     # elegantly upon revision of this function.
     lhvap = 2260. # 'kJ/kg'
     if qflx.units == 'mm/day':
-        qflx.units='kg/m2/day'
+#        qflx.units='kg/m2/day'
         qflxtmp = lhvap*qflx
-        qflxtmp.units = 'kJ/m2/day'
-        lhflx = reconcile_units(qflxtmp, udunits(1,'W/m2'),
-                                  preferred_units='W/m2')
+#        qflxtmp.units = 'kJ/m2/day'
+#        lhflx = reconcile_units(qflxtmp, udunits(1,'W/m^2'),
+#                                  preferred_units='W/m^2')
+    # 1 W = 86.4 kJ / day
+        lhflx = qflxtmp * 86.4
+        lhflx.units = 'W/m^s'
     else:
         print "ERROR: In function convert_qflx_to_Wms, input variable qflx must have units of mm/day."
         exit
@@ -1602,8 +1605,15 @@ def convert_lhflx_to_mmperday(lhflx):
     # The latent heat of vaporization for water is 2260 kJ/kg [SMB: 9 Feb 2015].
 
     lhvap = 2260. # 'kJ/kg'
-    lhflx_kg_per_m2_per_day = reconcile_units(lhflx, udunits(1,'kJ/m2/day'),
-                                              preferred_units='kJ/m2/day')
+
+    # TODO: Probably the unit conversions can be handled more
+    # elegantly upon revision of this function.
+#    lhflx_kg_per_m2_per_day = reconcile_units(lhflx, udunits(1,'kJ/m2/day'),
+#                                              preferred_units='kJ/m2/day')
+
+    # 1 W = 86.4 kJ / day
+    lhflx_kg_per_m2_per_day = lhflx / 86.4
+
     qflx = lhflx_kg_per_m2_per_day / lhvap
     qflx.units = 'mm/day'
     return qflx

--- a/src/python/computation/reductions.py
+++ b/src/python/computation/reductions.py
@@ -1585,7 +1585,11 @@ def reconcile_units( mv1, mv2, preferred_units=None ):
     If preferred units are specified, they will be used if possible."""
 
     # For QFLX and LHFLX variables, call dedicated functions instead.
-    if mv1.id.find('_QFLX_') or mv1.id.find('_LHFLX_'):
+    # TODO: The conditions for calling this function could perhaps be
+    # better-defined.  I primarily wanted to ensure that it would
+    # still work for the cases that the previous code worked for.
+    if mv1.id.find('_QFLX_') or mv1.id.find('_LHFLX_') or mv2.id.find('_QFLX_') \
+            or mv2.id.find('_LHFLX_') or (mv1.units=='kg/m2/s' and mv2.units=='mm/day'):
         flxconv.reconcile_energyflux_precip(mv1, mv2, preferred_units)
         return mv1, mv2
 

--- a/src/python/computation/reductions.py
+++ b/src/python/computation/reductions.py
@@ -1597,6 +1597,19 @@ def convert_qflx_to_Wms(qflx):
         exit
     return lhflx
 
+def convert_lhflx_to_mmperday(lhflx):
+    # To compare LHFLX and QFLX, need to unify these to a common variables
+    # e.g. LHFLX (latent heat flux in W/m^2) vs. QFLX (evaporation in mm/day)
+    # The latent heat of vaporization for water is 2260 kJ/kg [SMB: 9 Feb 2015].
+
+    lhvap = 2260.
+    lhvap.units = 'kJ/kg'
+    lhflx_kg_per_m2_per_day = reconcile_units(lhflx, udunits(1,'kJ/m2/day'),
+                                              preferred_units='kJ/m2/day')
+    qflx = lhflx_kg_per_m2_per_day / lhvap
+    qflx.units = 'mm/day'
+    return qflx
+
 def reconcile_units( mv1, mv2, preferred_units=None ):
     """Changes the units of variables (instances of TransientVariable) mv1,mv2 to be the same,
     mv1 is a TransientVariable or an axis.  mv2 may be a TransientVariable or axis, or it may

--- a/src/python/computation/reductions.py
+++ b/src/python/computation/reductions.py
@@ -1613,9 +1613,9 @@ def reconcile_units( mv1, mv2, preferred_units=None ):
         # Very ad-hoc, but more general would be less safe:
         # BES - set 3 does not seem to call it rv_QFLX. It is set3_QFLX_ft0_climos, so make this just a substring search
 #        if mv1.id[0:8]=="rv_QFLX_" and mv1.units=="kg/m2/s":
-        if mv1.id.find('_QFLX_') and mv1.units=="kg/m2/s":
-            preferred_units="mm/day"
-            mv1.units="mm/s"   # if 1 kg = 10^6 mm^3 as for water
+#        if mv1.id.find('_QFLX_') and mv1.units=="kg/m2/s":
+#            preferred_units="mm/day"
+#            mv1.units="mm/s"   # if 1 kg = 10^6 mm^3 as for water
         if mv1.units=='kg/m2/s' and mv2.units=='mm/day':
             preferred_units="mm/day"
             mv1.units="mm/s"   # if 1 kg = 10^6 mm^3 as for water

--- a/src/python/computation/reductions.py
+++ b/src/python/computation/reductions.py
@@ -1577,6 +1577,23 @@ def aminusb_ax2( mv1, mv2 ):
     aminusb.initDomain( ab_axes )
     return aminusb
 
+def convert_qflx_to_Wms(qflx):
+    # To compare LHFLX and QFLX, need to unify these to a common variables
+    # e.g. LHFLX (latent heat flux in W/m^2) vs. QFLX (evaporation in mm/day)
+    # The latent heat of vaporization for water is 2260 kJ/kg [SMB: 9 Feb 2015].
+
+    # TODO: Probably the unit conversions can be handled more
+    # elegantly upon revision of this function.
+    lhvap = 2260.
+    lhvap.units = 'kJ/kg'
+    if qflx.units == 'mm/day':
+        qflx.units='kg/m2/day'
+        qflxtmp = lhvap*qflx
+        qflxtmp.units = 'kJ/m2/day'
+        qflxWms = reconcile_units(qflxtmp, udunits(1,'W/m2'),
+                                  preferred_units='W/m2')
+    return qflxWms
+
 def reconcile_units( mv1, mv2, preferred_units=None ):
     """Changes the units of variables (instances of TransientVariable) mv1,mv2 to be the same,
     mv1 is a TransientVariable or an axis.  mv2 may be a TransientVariable or axis, or it may

--- a/src/python/computation/reductions.py
+++ b/src/python/computation/reductions.py
@@ -1584,8 +1584,7 @@ def convert_qflx_to_Wms(qflx):
 
     # TODO: Probably the unit conversions can be handled more
     # elegantly upon revision of this function.
-    lhvap = 2260.
-    lhvap.units = 'kJ/kg'
+    lhvap = 2260. # 'kJ/kg'
     if qflx.units == 'mm/day':
         qflx.units='kg/m2/day'
         qflxtmp = lhvap*qflx
@@ -1602,8 +1601,7 @@ def convert_lhflx_to_mmperday(lhflx):
     # e.g. LHFLX (latent heat flux in W/m^2) vs. QFLX (evaporation in mm/day)
     # The latent heat of vaporization for water is 2260 kJ/kg [SMB: 9 Feb 2015].
 
-    lhvap = 2260.
-    lhvap.units = 'kJ/kg'
+    lhvap = 2260. # 'kJ/kg'
     lhflx_kg_per_m2_per_day = reconcile_units(lhflx, udunits(1,'kJ/m2/day'),
                                               preferred_units='kJ/m2/day')
     qflx = lhflx_kg_per_m2_per_day / lhvap

--- a/src/python/computation/reductions.py
+++ b/src/python/computation/reductions.py
@@ -1592,7 +1592,7 @@ def convert_qflx_to_Wms(qflx):
 #        lhflx = reconcile_units(qflxtmp, udunits(1,'W/m^2'),
 #                                  preferred_units='W/m^2')
     # 1 W = 86.4 kJ / day
-        lhflx = qflxtmp * 86.4
+        lhflx = qflxtmp / 86.4
         lhflx.units = 'W/m^2'
     else:
         print "ERROR: In function convert_qflx_to_Wms, input variable qflx must have units of mm/day."
@@ -1612,7 +1612,7 @@ def convert_lhflx_to_mmperday(lhflx):
 #                                              preferred_units='kJ/m2/day')
 
     # 1 W = 86.4 kJ / day
-    lhflx_kg_per_m2_per_day = lhflx / 86.4
+    lhflx_kg_per_m2_per_day = lhflx * 86.4
 
     qflx = lhflx_kg_per_m2_per_day / lhvap
     qflx.units = 'mm/day'

--- a/src/python/computation/reductions.py
+++ b/src/python/computation/reductions.py
@@ -1590,7 +1590,8 @@ def reconcile_units( mv1, mv2, preferred_units=None ):
     # still work for the cases that the previous code worked for.
     if mv1.id.find('_QFLX_') or mv1.id.find('_LHFLX_') or mv2.id.find('_QFLX_') \
             or mv2.id.find('_LHFLX_') or (mv1.units=='kg/m2/s' and mv2.units=='mm/day'):
-        flxconv.reconcile_energyflux_precip(mv1, mv2, preferred_units)
+
+        mv1,mv2 = flxconv.reconcile_energyflux_precip(mv1, mv2, preferred_units)
         return mv1, mv2
 
 # This probably needs expanded to be more general purpose for unit conversions.

--- a/src/python/packages/amwg/amwg.py
+++ b/src/python/packages/amwg/amwg.py
@@ -12,6 +12,7 @@ from metrics.frontend import *
 from metrics.common.id import *
 from metrics.fileio import stationData
 from metrics.packages.amwg.derivations import *
+from metrics.packages.amwg.derivations import qflx_lhflx_conversions as flxconv
 from unidata import udunits
 import cdutil.times, numpy
 from numbers import Number
@@ -242,13 +243,14 @@ class amwg_plot_spec(plot_spec):
                 func=(lambda x: x) ) ],
         # To compare LHFLX and QFLX, need to unify these to a common variable
         # e.g. LHFLX (latent heat flux in W/m^2) vs. QFLX (evaporation in mm/day).
-        # [SMB: 9 Feb 2015]
+        # The conversion functions are defined in qflx_lhflx_conversions.py.
+        # [SMB: 25 Feb 2015]
         'LHFLX':[derived_var(
                 vid='LHFLX', inputs=['QFLX'], outputs=['LHFLX'],
-                func=(lambda x: convert_qflx_to_Wms(x)) ) ],
+                func=(lambda x: flxconv.convert_energyflux_precip(x, preferred_units="W/m^2")) ) ],
         'QFLX':[derived_var(
                 vid='QFLX', inputs=['LHFLX'], outputs=['QFLX'],
-                func=(lambda x: convert_lhflx_to_mmperday(x)) ) ]
+                func=(lambda x: flxconv.convert_energyflux_precip(x, preferred_units="mm/day")) ) ]
         }
     @staticmethod
     def _list_variables( model, obs ):

--- a/src/python/packages/amwg/amwg.py
+++ b/src/python/packages/amwg/amwg.py
@@ -245,7 +245,7 @@ class amwg_plot_spec(plot_spec):
         # [SMB: 9 Feb 2015]
         'LHFLX':[derived_var(
                 vid='LHFLX', inputs=['QFLX'], outputs=['LHFLX'],
-                func=(lambda x: convert_qflx_to_Wms(x)) ) ]
+                func=(lambda x: convert_qflx_to_Wms(x)) ) ],
         'QFLX':[derived_var(
                 vid='QFLX', inputs=['LHFLX'], outputs=['QFLX'],
                 func=(lambda x: convert_lhflx_to_mmperday(x)) ) ]

--- a/src/python/packages/amwg/amwg.py
+++ b/src/python/packages/amwg/amwg.py
@@ -239,7 +239,13 @@ class amwg_plot_spec(plot_spec):
 
         'TGCLDLWP':[derived_var(
                 vid='TGCLDLWP', inputs=['TGCLDLWP_OCEAN'], outputs=['TGCLDLWP'],
-                func=(lambda x: x) ) ]
+                func=(lambda x: x) ) ],
+        # To compare LHFLX and QFLX, need to unify these to a common variables
+        # e.g. LHFLX (latent heat flux in W/m^2) vs. QFLX (evaporation in mm/day)
+        # The latent heat of vaporization for water is 2260 kJ/kg [SMB: 9 Feb 2015].
+        'LHFLX':[derived_var(
+                vid='LHFLX', inputs=['QFLX'], outputs=['LHFLX'],
+                func=(lambda x: convert_qflx_to_Wms(x)) ) ]
         }
     @staticmethod
     def _list_variables( model, obs ):

--- a/src/python/packages/amwg/amwg.py
+++ b/src/python/packages/amwg/amwg.py
@@ -246,6 +246,9 @@ class amwg_plot_spec(plot_spec):
         'LHFLX':[derived_var(
                 vid='LHFLX', inputs=['QFLX'], outputs=['LHFLX'],
                 func=(lambda x: convert_qflx_to_Wms(x)) ) ]
+        'QFLX':[derived_var(
+                vid='QFLX', inputs=['LHFLX'], outputs=['QFLX'],
+                func=(lambda x: convert_lhflx_to_mmperday(x)) ) ]
         }
     @staticmethod
     def _list_variables( model, obs ):

--- a/src/python/packages/amwg/amwg.py
+++ b/src/python/packages/amwg/amwg.py
@@ -241,8 +241,8 @@ class amwg_plot_spec(plot_spec):
                 vid='TGCLDLWP', inputs=['TGCLDLWP_OCEAN'], outputs=['TGCLDLWP'],
                 func=(lambda x: x) ) ],
         # To compare LHFLX and QFLX, need to unify these to a common variables
-        # e.g. LHFLX (latent heat flux in W/m^2) vs. QFLX (evaporation in mm/day)
-        # The latent heat of vaporization for water is 2260 kJ/kg [SMB: 9 Feb 2015].
+        # e.g. LHFLX (latent heat flux in W/m^2) vs. QFLX (evaporation in mm/day).
+        # [SMB: 9 Feb 2015]
         'LHFLX':[derived_var(
                 vid='LHFLX', inputs=['QFLX'], outputs=['LHFLX'],
                 func=(lambda x: convert_qflx_to_Wms(x)) ) ]

--- a/src/python/packages/amwg/amwg.py
+++ b/src/python/packages/amwg/amwg.py
@@ -240,7 +240,7 @@ class amwg_plot_spec(plot_spec):
         'TGCLDLWP':[derived_var(
                 vid='TGCLDLWP', inputs=['TGCLDLWP_OCEAN'], outputs=['TGCLDLWP'],
                 func=(lambda x: x) ) ],
-        # To compare LHFLX and QFLX, need to unify these to a common variables
+        # To compare LHFLX and QFLX, need to unify these to a common variable
         # e.g. LHFLX (latent heat flux in W/m^2) vs. QFLX (evaporation in mm/day).
         # [SMB: 9 Feb 2015]
         'LHFLX':[derived_var(

--- a/src/python/packages/amwg/amwg.py
+++ b/src/python/packages/amwg/amwg.py
@@ -247,10 +247,10 @@ class amwg_plot_spec(plot_spec):
         # [SMB: 25 Feb 2015]
         'LHFLX':[derived_var(
                 vid='LHFLX', inputs=['QFLX'], outputs=['LHFLX'],
-                func=(lambda x: flxconv.convert_energyflux_precip(x, preferred_units="W/m^2")) ) ],
+                func=(lambda x: x) ) ],
         'QFLX':[derived_var(
                 vid='QFLX', inputs=['LHFLX'], outputs=['QFLX'],
-                func=(lambda x: flxconv.convert_energyflux_precip(x, preferred_units="mm/day")) ) ]
+                func=(lambda x: x) ) ]
         }
     @staticmethod
     def _list_variables( model, obs ):

--- a/src/python/packages/amwg/derivations/qflx_lhflx_conversions.py
+++ b/src/python/packages/amwg/derivations/qflx_lhflx_conversions.py
@@ -29,8 +29,10 @@ def reconcile_energyflux_precip(mv1, mv2, preferred_units=None):
             preferred_units = mv2.units
     # syntax correction (just in case)
         if preferred_units=='W/m2' or preferred_units=='W/m^2':
-            mv1 = convert_energyflux_precip(mv, preferred_units)
-
+            if mv1.units!=preferred_units:
+                mv1 = convert_energyflux_precip(mv1, preferred_units)
+            if mv2.units!=preferred_units:
+                mv2 = convert_energyflux_precip(mv2, preferred_units)
     else:
         print "ERROR: missing units in arguments to reconcile_energyflux_precip."
         exit
@@ -41,26 +43,52 @@ def convert_energyflux_precip(mv, preferred_units):
 
     # The latent heat of vaporization for water is 2260 kJ/kg
     lhvap = 2260. # 'kJ/kg'
+    secondsperday = 86400.
 
     # syntax correction (jus in case)
     if  mv.units=='W/m2' and preferred_units=='W/m^2':
         mv.units='W/m^2'
     # convert precip between kg/m2/s and mm/day
-    elif mv=='kg/m2/s' and preferred_units=="mm/day":
-        mv.units="mm/day"   # if 1 kg = 10^6 mm^3 as for water
-    elif mv=='mm/day' and preferred_units=="kg/m2/s":
-        mv.units="kg/m2/s"   # if 1 kg = 10^6 mm^3 as for water
+    elif mv.units=='kg/m2/s' and preferred_units=="mm/day":
+        mv = mv * secondsperday # convert to kg/m2/s [= mm/s]
+        mv.units="mm/s"         # [if 1 kg = 10^6 mm^3 as for water]
+    elif mv.units=='mm/day' and preferred_units=="kg/m2/s":
+        mv = mv / secondsperday # convert to mm/sec [= kg/m2/s]
+        mv.units="kg/m2/s"      # [if 1 kg = 10^6 mm^3 as for water]
     # convert between energy flux (W/m2) and water flux (mm/day)
     elif mv.units=='mm/day' and preferred_units=='W/m^2':
         # 1 W = 86.4 kJ / day
-        mv = mv * lhvap / 86.4
+        mv = mv * lhvap / 86.4 
         mv.units = 'W/m^2'
-    elif  mv.units=='W/m^2' and preferred_units=='mm/day':
+    elif mv.units=='W/m^2' and preferred_units=='mm/day':
         mv = mv * 86.4 / lhvap
         mv.units = 'mm/day'
 
     else:
         print "ERROR: unknown / invalid units in arguments to reconcile_energyflux_precip."
         exit
+
+#    # Code to convert units using udunits if still needed (code
+#    # adapted from reductions.reconcile_units()) Note that I
+#    # hard-coded all the conversions above for the moment, so this is
+#    # not needed, but I left it here as a template in case we want to
+#    # generalize later. (SMB)
+#
+#
+#    tmp = udunits(1.0,mv.units)
+#    try:
+#        s,i = tmp.how(preferred_units)
+#    except Exception as e:
+#        # conversion not possible.
+#        print "ERROR could not convert from",mv.units,"to",preferred_units
+#        raise e
+#    if hasattr(mv,'id'):  # yes for TransientVariable, no for udunits
+#        mvid = mv.id
+#    if not ( numpy.allclose(s,1.0) and numpy.allclose(i,0.0) ):
+#        # The following line won't work if mv is an axis.
+#        mv = s*mv + i
+#        if hasattr(mv2,'id'):
+#            mv.id = mvid
+#    mv.units = preferred_units
 
     return mv

--- a/src/python/packages/amwg/derivations/qflx_lhflx_conversions.py
+++ b/src/python/packages/amwg/derivations/qflx_lhflx_conversions.py
@@ -22,19 +22,28 @@ def reconcile_energyflux_precip(mv1, mv2, preferred_units=None):
 
     # If preferred_units is not provided, assume units of mv2 assumed
     # to be the preferred units.
-    if preferred_units is None:
-       preferred_units = mv2.units
-#        if mv2.id.find('_QFLX_'):
-#            preferred_units='mm/day'
-#        elif mv2.id.find('_LHFLX_'):
-#            preferred_units='W/m^2'
-    # syntax correction (just in case)
-    if preferred_units=='W/m2':
-        preferred_units='W/m^2'
 
-    if hasattr(mv1,'units') and hasattr(mv2,'units') and\
-            (preferred_units is not None):
+    print "preferred_units passed to reconcile_energyflux_precip: ", preferred_units
 
+    if hasattr(mv1,'units') and hasattr(mv2,'units'):
+
+        # First, set preferred_units if needed
+        if preferred_units is None:
+            if ('_QFLX_' in mv2.id) or ('_QFLX' in mv1.id):
+                print "Setting preferred_units='mm/day'"
+                preferred_units='mm/day'
+            if ('_LHFLX_' in mv2.id) or ('_LHFLX' in mv1.id):
+                print "Setting preferred_units='W/m^2'"
+                preferred_units='W/m^2'
+            if preferred_units is None:
+                print "Setting preferred_units to mv.units=",mv2.units
+                preferred_units = mv2.units
+
+        # syntax correction (just in case)
+        if preferred_units=='W/m2':
+            preferred_units='W/m^2'
+
+        # Now do conversions to preferred_units (only if needed)
         if mv1.units!=preferred_units:
             mv1 = convert_energyflux_precip(mv1, preferred_units)
         if mv2.units!=preferred_units:
@@ -60,23 +69,28 @@ def convert_energyflux_precip(mv, preferred_units):
         mv.units='W/m^2'
 
     # convert precip between kg/m2/s and mm/day
-    if mv.units=='kg/m2/s' and preferred_units=="mm/day":
+    if mv.units=="kg/m2/s" and preferred_units=="mm/day":
         mv = mv * secondsperday # convert to kg/m2/s [= mm/s]
         mv.units="mm/day"         # [if 1 kg = 10^6 mm^3 as for water]
+
     elif mv.units=='mm/day' and preferred_units=="kg/m2/s":
         mv = mv / secondsperday # convert to mm/sec [= kg/m2/s]
         mv.units="kg/m2/s"      # [if 1 kg = 10^6 mm^3 as for water]
+
     # convert between energy flux (W/m2) and water flux (mm/day)
     elif mv.units=='mm/day' and preferred_units=='W/m^2':
         # 1 W = 86.4 kJ / day
         mv = mv * lhvap / kJperday
         mv.units = 'W/m^2'
+
     elif mv.units=='W/m^2' and preferred_units=='mm/day':
         mv = mv * kJperday / lhvap
         mv.units = 'mm/day'
 
     else:
         print "ERROR: unknown / invalid units in arguments to reconcile_energyflux_precip."
+        print "mv.units = ", mv.units
+        print "preferred_units = ", preferred_units
         exit
 
     mv.id = mvid # reset variable id

--- a/src/python/packages/amwg/derivations/qflx_lhflx_conversions.py
+++ b/src/python/packages/amwg/derivations/qflx_lhflx_conversions.py
@@ -75,28 +75,4 @@ def convert_energyflux_precip(mv, preferred_units):
 
     mv.id = mvid # reset variable id
 
-#    # Code to convert units using udunits if still needed (code
-#    # adapted from reductions.reconcile_units()) Note that I
-#    # hard-coded all the conversions above for the moment, so this is
-#    # not needed, but I left it here as a template in case we want to
-#    # generalize later. (SMB)
-#
-#
-#    tmp = udunits(1.0,mv.units)
-#    try:
-#        s,i = tmp.how(preferred_units)
-#    except Exception as e:
-#        # conversion not possible.
-#        print "ERROR could not convert from",mv.units,"to",preferred_units
-#        raise e
-#    if hasattr(mv,'id'):  # yes for TransientVariable, no for udunits
-#        mvid = mv.id
-#    if not ( numpy.allclose(s,1.0) and numpy.allclose(i,0.0) ):
-#        # The following line won't work if mv is an axis.
-#        mv = s*mv + i
-#        if hasattr(mv2,'id'):
-#            mv.id = mvid
-#    mv.units = preferred_units
-
-
     return mv

--- a/src/python/packages/amwg/derivations/qflx_lhflx_conversions.py
+++ b/src/python/packages/amwg/derivations/qflx_lhflx_conversions.py
@@ -78,6 +78,10 @@ def convert_energyflux_precip(mv, preferred_units):
         mv.units="kg/m2/s"      # [if 1 kg = 10^6 mm^3 as for water]
 
     # convert between energy flux (W/m2) and water flux (mm/day)
+    elif mv.units=="kg/m2/s" and preferred_units=="W/m^2":
+        mv = mv * kJperday * secondsperday * lhvap
+        mv.units = 'W/m^2'
+
     elif mv.units=='mm/day' and preferred_units=='W/m^2':
         # 1 W = 86.4 kJ / day
         mv = mv * lhvap / kJperday

--- a/src/python/packages/amwg/derivations/qflx_lhflx_conversions.py
+++ b/src/python/packages/amwg/derivations/qflx_lhflx_conversions.py
@@ -1,0 +1,66 @@
+#!/usr/local/uvcdat/bin/python
+
+# Functions to convert between representations of energy flux and
+# water flux (precipitation and evoporation) variables.
+
+# TODO: perhaps move the physical constants used here to atmconst.py.
+#       These are:
+#          - latent heat of vaporization (water)
+#          - density (water)
+
+def reconcile_energyflux_precip(mv1, mv2, preferred_units=None):
+    # To compare LHFLX and QFLX, need to unify these to a common variables
+    # e.g. LHFLX (latent heat flux in W/m^2) vs. QFLX (evaporation in mm/day)
+    #
+    # If preferred_units is not provided, the units of mv2 will be
+    # assumed to be the preferred units.
+    #
+    # This function is used by the derived_variable definitions in
+    # amwg_plot_spec's standard_variables (within amwg.py).
+    #
+    # Author: S.M. Burrows, 9 Feb 2015.
+
+    if hasattr(mv1,'units') and hasattr(mv2,'units') and\
+            (preferred_units is not None or mv1.units!=mv2.units):
+
+    # If preferred_units is not provided, assume units of mv2 assumed
+    # to be the preferred units.
+        if preferred_units is None:
+            preferred_units = mv2.units
+    # syntax correction (just in case)
+        if preferred_units=='W/m2' or preferred_units=='W/m^2':
+            mv1 = convert_energyflux_precip(mv, preferred_units)
+
+    else:
+        print "ERROR: missing units in arguments to reconcile_energyflux_precip."
+        exit
+
+    return mv1,mv2
+
+def convert_energyflux_precip(mv, preferred_units):
+
+    # The latent heat of vaporization for water is 2260 kJ/kg
+    lhvap = 2260. # 'kJ/kg'
+
+    # syntax correction (jus in case)
+    if  mv.units=='W/m2' and preferred_units=='W/m^2':
+        mv.units='W/m^2'
+    # convert precip between kg/m2/s and mm/day
+    elif mv=='kg/m2/s' and preferred_units=="mm/day":
+        mv.units="mm/day"   # if 1 kg = 10^6 mm^3 as for water
+    elif mv=='mm/day' and preferred_units=="kg/m2/s":
+        mv.units="kg/m2/s"   # if 1 kg = 10^6 mm^3 as for water
+    # convert between energy flux (W/m2) and water flux (mm/day)
+    elif mv.units=='mm/day' and preferred_units=='W/m^2':
+        # 1 W = 86.4 kJ / day
+        mv = mv * lhvap / 86.4
+        mv.units = 'W/m^2'
+    elif  mv.units=='W/m^2' and preferred_units=='mm/day':
+        mv = mv * 86.4 / lhvap
+        mv.units = 'mm/day'
+
+    else:
+        print "ERROR: unknown / invalid units in arguments to reconcile_energyflux_precip."
+        exit
+
+    return mv

--- a/src/python/packages/amwg/derivations/qflx_lhflx_conversions.py
+++ b/src/python/packages/amwg/derivations/qflx_lhflx_conversions.py
@@ -20,16 +20,21 @@ def reconcile_energyflux_precip(mv1, mv2, preferred_units=None):
     #
     # Author: S.M. Burrows, 9 Feb 2015.
 
-    if hasattr(mv1,'units') and hasattr(mv2,'units') and\
-            (preferred_units is not None or mv1.units!=mv2.units):
-
     # If preferred_units is not provided, assume units of mv2 assumed
     # to be the preferred units.
-        if preferred_units is None:
-            preferred_units = mv2.units
+    if preferred_units is None:
+       preferred_units = mv2.units
+#        if mv2.id.find('_QFLX_'):
+#            preferred_units='mm/day'
+#        elif mv2.id.find('_LHFLX_'):
+#            preferred_units='W/m^2'
     # syntax correction (just in case)
-        if preferred_units=='W/m2' or preferred_units=='W/m^2':
-            preferred_units='W/m^2'
+    if preferred_units=='W/m2':
+        preferred_units='W/m^2'
+
+    if hasattr(mv1,'units') and hasattr(mv2,'units') and\
+            (preferred_units is not None):
+
         if mv1.units!=preferred_units:
             mv1 = convert_energyflux_precip(mv1, preferred_units)
         if mv2.units!=preferred_units:
@@ -50,11 +55,12 @@ def convert_energyflux_precip(mv, preferred_units):
     if hasattr(mv,'id'):
         mvid = mv.id
 
-    # syntax correction (jus in case)
-    if  mv.units=='W/m2' and preferred_units=='W/m^2':
+    # syntax correction (just in case)
+    if  mv.units=='W/m2':
         mv.units='W/m^2'
+
     # convert precip between kg/m2/s and mm/day
-    elif mv.units=='kg/m2/s' and preferred_units=="mm/day":
+    if mv.units=='kg/m2/s' and preferred_units=="mm/day":
         mv = mv * secondsperday # convert to kg/m2/s [= mm/s]
         mv.units="mm/day"         # [if 1 kg = 10^6 mm^3 as for water]
     elif mv.units=='mm/day' and preferred_units=="kg/m2/s":


### PR DESCRIPTION
This code to enables comparison of LHFLX (latent heat flux in W/m^2) vs. QFLX (evaporation in mm/day), if only one of them is present in the provided model/obs file.  I added functions in reductions.py to convert QFLX to LHFLX and LHFLX to QFLX, by either multiplying or dividing by the latent heat of vaporization, and converting the units.  Then I added derived_variables in amwg.py.  I assume/believe that the code will look for a derived_variable only if it doesn’t find a variable defined in the file with the name it is looking for.  So I added a QFLX variable and an LHFLX variable.  Now, if it looks for LHFLX in a file and can’t find it, it will look for QFLX and convert it if possible, and vice versa.

It appears to work — see plots below:
![setso_ann_lhflx_laryea_s_extratropics-combined](https://cloud.githubusercontent.com/assets/6811403/6120620/f161ef26-b08c-11e4-9407-07315ba2316c.png)
![setso_ann_qflx_laryea_s_extratropics-combined](https://cloud.githubusercontent.com/assets/6811403/6120619/f1608ac8-b08c-11e4-8d8c-e5690471881e.png)