### PR TITLE
work around vcs bug

### DIFF
--- a/src/python/frontend/diags.py
+++ b/src/python/frontend/diags.py
@@ -572,6 +572,8 @@ def run_diagnostics_from_filetables( opts, modelfts, obsfts ):
                                 number_diagnostic_plots += 1
                                 print "wrote table",resc.title," to",filenames
 
+    vcanvas2.close()
+    vcanvas.close()
     print "total number of (compound) diagnostic plots generated =", number_diagnostic_plots
 
 if __name__ == '__main__':


### PR DESCRIPTION
on ubuntu canvas need to be closed in reverse order than the were opened
otherwise we get a seg fault