### PR TITLE
fix bug with lat,lon in variable list

### DIFF
--- a/src/python/frontend/climatology.py
+++ b/src/python/frontend/climatology.py
@@ -318,7 +318,8 @@ def climos( fileout_template, seasonnames, varnames, datafilenames, omitBySeason
                      'SNOWHICE', 'SNOWHLND', 'SOLIN', 'SWCF', 'T', 'TAUX', 'TAUY', 'TGCLDIWP',
                      'TGCLDLWP', 'TMQ', 'TREFHT', 'TS', 'U', 'U10', 'UU', 'V', 'VD01', 'VQ', 'VT',
                      'VU', 'VV', 'WSUB', 'Z3', 'P0', 'time_bnds', 'area', 'hyai', 'hyam', 'hybi',
-                     'hybm', 'lat', 'lon' ]
+                     'hybm']
+        # These were originally on the list, but they're axes: ['lat', 'lon' ]
 
     dt = 0      # specifies climatology file
     redfilenames = []

--- a/src/python/frontend/inc_reduce.py
+++ b/src/python/frontend/inc_reduce.py
@@ -200,7 +200,7 @@ def initialize_redfile_from_datafile( redfilename, varnames, datafilen, dt=-1, i
         except:
             # Probably an axis.  Most of what we're doing here makes no sense for an axis.
             # FWIW, this would get the type name: dtnom = f[varn].dtype('spam').name
-            print "jfp WARNING, averager will ignore axis", varn
+            print "WARNING, averager will ignore axis", varn
             continue
         if dtnom.find('string')==0:
             # We can't handle string variables.

--- a/src/python/frontend/inc_reduce.py
+++ b/src/python/frontend/inc_reduce.py
@@ -195,7 +195,14 @@ def initialize_redfile_from_datafile( redfilename, varnames, datafilen, dt=-1, i
         if f[varn] is None:
             print "WARNING,",varn,"was not found in",datafilen
             continue
-        if f[varn].dtype.name.find('string')==0:
+        try:
+            dtnom = f[varn].dtype.name  # works for variables
+        except:
+            # Probably an axis.  Most of what we're doing here makes no sense for an axis.
+            # FWIW, this would get the type name: dtnom = f[varn].dtype('spam').name
+            print "jfp WARNING, averager will ignore axis", varn
+            continue
+        if dtnom.find('string')==0:
             # We can't handle string variables.
             print "jfp WARNING, ignoring string variable",varn
             continue


### PR DESCRIPTION
The lat and lon axes were in the variable list "AMWG", but it is inappropriate to compute a climatology of an axis.  This bug fix removes these two axes from that variable list, and changes inc_reduce.py so as not to crash on them.  Jerry Potter had reported the bug this morning.