### PR TITLE
Fix a couple of broken things in metadiags

### DIFF
--- a/src/python/frontend/metadiags.py
+++ b/src/python/frontend/metadiags.py
@@ -45,6 +45,7 @@ def getCollections(pname):
    return colls
 
 def makeTables(collnum, model_dict, obspath, outpath, pname, outlog):
+   collnum = collnum.lower()
    seasons = diags_collection[collnum].get('seasons', ['ANN'])
    regions = diags_collection[collnum].get('regions', ['Global'])
    vlist = list( set(diags_collection[collnum].keys()) - set(collection_special_vars))
@@ -221,6 +222,7 @@ def generatePlots(model_dict, obspath, outpath, pname, xmlflag, colls=None):
    # Now, loop over collections.
    for collnum in colls:
       print 'Working on collection ', collnum
+      collnum = collnum.lower()
       # Special case the tables since they are a bit special. (at least amwg)
       if diags_collection[collnum].get('tables', False) != False:
          makeTables(collnum, model_dict, obspath, outpath, pname, outlog)

--- a/src/python/packages/amwg/amwg.py
+++ b/src/python/packages/amwg/amwg.py
@@ -909,9 +909,10 @@ class amwg_plot_set41(amwg_plot_set4and41):
         diags --outputdir $HOME/Documents/Climatology/ClimateData/diagout/ 
         --model path=$HOME/uvcmetrics_test_data/cam35_data/,climos=yes 
         --obs path=$HOME/uvcmetrics_test_data/obs_data/,filter="f_startswith('NCEP')",climos=yes 
-        --package AMWG --set 41 --vars T --seasons ANN"""
-    name = '41 - Horizontal Contour Plots of Meridional Means'
-    number = '41'    
+        --package AMWG --set 4A --vars T --seasons ANN"""
+    name = '4A - Horizontal Contour Plots of Meridional Means'
+    number = '4A'
+
 class amwg_plot_set5and6(amwg_plot_spec):
     """represents one plot from AMWG Diagnostics Plot Sets 5 and 6  <actually only the contours, set 5>
     NCAR has the same menu for both plot sets, and we want to ease the transition from NCAR


### PR DESCRIPTION
This fixes some metadata to use what I believe is the "proper" name of "4A" rather than "41", and also makes metadiags a smidgen more forgiving when you specify plotsets.