### PR TITLE
Minor cleanups for ease of use

### DIFF
--- a/src/python/fileio/findfiles.py
+++ b/src/python/fileio/findfiles.py
@@ -322,11 +322,11 @@ class dirtree_datafiles( basic_datafiles ):
         if os.path.isfile(root):
             self.files += [root]
         elif os.path.isdir(root):
-            for dirpath, dirname, filenames in os.walk(root):
-                dirpath = os.path.expanduser(dirpath)
-                dirpath = os.path.abspath(dirpath)
+            for dirpath, dirnames, filenames in os.walk(root):
+                # Remove any hidden directories from the walk before we get into them.
+                dirnames[:] = [d for d in dirnames if d[0] != "."]
                 # Skip hidden files and anything that fails the filter.
-                self.files += [ os.path.join(dirpath,f) for f in filenames if filt(f) and f[0] != "." ]
+                self.files += [ os.path.join(dirpath, f) for f in filenames if filt(f) and f[0] != "." and os.path.basename(dirpath)[0] != "." ]
         else:   # no more checking, but still could be valid - maybe its a url or something:
             self.files += [root]
             logger.warning("Candidate data source is not a file or directory. %s What is it????", self.files[0])

--- a/src/python/frontend/metadiags.py
+++ b/src/python/frontend/metadiags.py
@@ -929,6 +929,3 @@ module load uvcdat/batch
     if opts["do_upload"]:
         upload_path = os.path.join(outpath, package.lower())
         subprocess.call(["upload_output", "--server", hostname, upload_path])
-
-    # Used to quash stdout/stderr that isn't properly logged by diags.
-    spam_file.close()


### PR DESCRIPTION
Fixes an issue where filetable would descend into hidden directories (causes issues with .svn folders, like, say, in an obs repo), and makes stdout/stderr get appended to metadiags generated logfiles, which makes it a bit easier to debug problems with metadiags (so you can actually see the openblas errors and others in the log files, rather than just wondering what went wrong).