### PR TITLE
Comand line model name for metadiags

### DIFF
--- a/src/python/frontend/metadiags.py
+++ b/src/python/frontend/metadiags.py
@@ -214,6 +214,7 @@ def generatePlots(model_dict, obspath, outpath, pname, xmlflag, data_hash, colls
         defaultft1 = None
         raw1 = None
         climo1 = None
+        name1 = None
 
     if climo0 != None:
         cf0 = 'yes'
@@ -377,7 +378,6 @@ def generatePlots(model_dict, obspath, outpath, pname, xmlflag, data_hash, colls
                     xmlstr = ' --xml no'
                 else:
                     xmlstr = ''
-
                 if o != 'NA' and obspath != None:
                     obsfname = diags_obslist[o]['filekey']
                     obsstr = '--obs path='+obspath+',climos=yes,filter="f_startswith(\''+obsfname+'\')"'
@@ -423,8 +423,14 @@ def generatePlots(model_dict, obspath, outpath, pname, xmlflag, data_hash, colls
                 if len(simple_vars) != 0:
                     varstr = '--vars '+' '.join(simple_vars)
                     pstr1 = '--model path=%s,climos=%s,type=model' % (modelpath, cf0)
+                    #append the name if passed from command line
+                    if name0 != None:
+                        pstr1 += ',name=' + name0
                     if modelpath1 != None:
                         pstr2 = '--model path=%s,climos=%s,type=model' % (modelpath1, cf1)
+                        #append the name if passed from command line
+                        if name1 != None:
+                            pstr2 += ',name=' + name1
                     else:
                         pstr2 = ''
                     cmdline = (def_executable, pstr1, pstr2, obsstr, optionsstr, packagestr, setstr, seasonstr, varstr, outstr, xmlstr, prestr, poststr, regionstr)


### PR DESCRIPTION
This branch corrects an issue so that specifying the model name gets passed through to the individual diags run.  The branch originates from master and passes all test.