### PR TITLE
Fix mass weights to get reasonable reduced variables.

### DIFF
--- a/src/python/packages/amwg/amwg4.py
+++ b/src/python/packages/amwg/amwg4.py
@@ -171,6 +171,7 @@ class amwg_plot_set4and4A(amwg_plot_plan):
             self.plotall_id: [self.plot1_id, self.plot2_id, self.plot3_id ]
             }
         self.computation_planned = True
+
     def customizeTemplates(self, templates, data=None, varIndex=None, graphicMethod=None, var=None,
                            uvcplotspec=None ):
         """This method does what the title says.  It is a hack that will no doubt change as diags changes."""

--- a/src/python/packages/amwg/amwg5.py
+++ b/src/python/packages/amwg/amwg5.py
@@ -194,6 +194,7 @@ class amwg_plot_set5(amwg_plot_plan):
         else:
             self.composite_plotspecs = {}
         self.computation_planned = True
+
     def vars_normal_contours( self, filetable, varnom, seasonid, aux=None ):
         reduced_varlis = [
             reduced_variable(


### PR DESCRIPTION
For mass weights where the data's levels are pressure levels, comput weights correctly whether the levels are arranged top-down or bottom-up.  This fixes a problem @mcenerney1 saw with unreasonable values for min,max.  How did it happen?  When the levels are in an unexpected order, you get some negative weights.  The cdutil averager only works with positive weights.