### PR TITLE
Fixes an os.fork exception when Popen tries to open to many processes

### DIFF
--- a/src/python/frontend/metadiags.py
+++ b/src/python/frontend/metadiags.py
@@ -2,6 +2,7 @@
 
 # This file converts a dictionary file (like amwgmaster.py or lmwgmaster.py) to a series of diags.py commands.
 import sys, getopt, os, subprocess, logging, pdb
+from time import sleep
 from argparse import ArgumentParser
 from functools import partial
 from collections import OrderedDict
@@ -794,7 +795,12 @@ def runcmdline(cmdline, outlogdir, dryrun=False):
         cmd = " ".join(cmdline)
         tmpfile = tempfile.NamedTemporaryFile()
         if True:   # For some testing purposes, set to False to turn off all plotting.
-            active_processes.append(subprocess.Popen(cmd, stdout=tmpfile, stderr=tmpfile, shell=True))
+            while True:
+                try:
+                    active_processes.append(subprocess.Popen(cmd, stdout=tmpfile, stderr=tmpfile, shell=True))
+                    break
+                except:
+                    sleep(1)
             DIAG_TOTAL += 1
             PID = active_processes[-1].pid
             pid_to_tmpfile[PID] = tmpfile


### PR DESCRIPTION
When I run metadiags on acme1, it fails 100% of the time because of an uncaught exception. Turns out even though MAX_PROC is getting set to 192 (the number of cores), metadiags is still trying to open more simultaneous processes then the system can handle. Ive added a small check to catch this failure, wait a second, and try again. I tested it on acme1 and it works fine, only triggering about 6-8 times per run. All other systems where it was previously working should be unaffected.